### PR TITLE
Remove the version number Postgres in the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ group :test do
 end
 
 group :production do
-  gem 'pg', '1.2.3'
+  gem 'pg'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem


### PR DESCRIPTION
# Removing the Version Number on Postgres

- I removed the version number from the Postgres for the app to make use of any compctible version on Heroku